### PR TITLE
Add Usage Documentation for Immutable Backup Buckets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@
 * [Readiness of Shoot Worker Nodes](usage/advanced/node-readiness.md)
 * [Cleanup of Shoot clusters in deletion](usage/advanced/shoot_cleanup.md)
 * [Tolerations](usage/advanced/tolerations.md)
+* [Immutable Backup Buckets](usage/advanced/immutable-backup-buckets.md)
 
 ## [API Reference](api-reference/README.md)
 

--- a/docs/usage/advanced/immutable-backup-buckets.md
+++ b/docs/usage/advanced/immutable-backup-buckets.md
@@ -28,7 +28,7 @@ The **provider extension** will:
 * 🚫 **Prevent changes** that would weaken the policy (reduce retention period or disable immutability).
 * 🕑 **Manage deletion lifecycle**: If retention lock prevents immediate deletion of objects, a deletion policy will apply when allowed.
 
-> \[!IMPORTANT]
+> [!IMPORTANT]
 > Once a bucket's immutability is **locked** at the cloud provider level, it cannot be removed or shortened—even by administrators or operators.
 
 ## Provider Support

--- a/docs/usage/advanced/immutable-backup-buckets.md
+++ b/docs/usage/advanced/immutable-backup-buckets.md
@@ -1,0 +1,104 @@
+---
+title: Immutable Backup Buckets
+---
+
+# Immutable Backup Buckets
+
+## Overview 
+
+Immutable backup buckets ensure that etcd backups cannot be modified or deleted after creation, leveraging immutability features provided by supported cloud providers. This is essential for meeting security, compliance, and operational requirements.
+
+> [!NOTE]
+> For background, see [Gardener Issue #10866](https://github.com/gardener/gardener/issues/10866).
+
+## Core Concepts
+
+Gardener supports immutable backup buckets for `AWS`, `GCP`, and `Azure` via their respective provider extensions. When enabled, the extension will:
+
+- **Create** buckets with the specified immutability policy if they do not exist.
+- **Reconcile** existing buckets to enforce the desired immutability policy.
+- **Prevent** reducing the retention period or disabling immutability once the policy is locked.
+- **Apply** lifecycle-based delayed deletion on `GCP` and `Azure` when immediate deletion is not permitted.
+
+> [!IMPORTANT]
+> Once immutability is locked, it cannot be disabled or shortened.
+
+## Admission Webhook Enforcement
+
+An admission webhook ensures:
+
+- **Locking:** Once `locked: true`, immutability cannot be disabled.
+- **Retention:** Once the retention period is set and locked, it cannot be decreased.
+
+## Configuration
+
+To enable immutable backup buckets, specify the immutability settings in `.spec.backup.providerConfig` in the `Seed` resource. The gardenlet will automatically create or update the bucket according to the configuration.
+
+- See [BackupBucket Resource Contract](../../extensions/resources/backupbucket.md)
+- See [Gardenlet Controller Concepts – BackupBucket Controller](../../concepts/gardenlet.md#backupbucket-controller)
+
+## Example Configurations
+
+### `GCP`
+
+```yaml
+apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+kind: BackupBucketConfig
+metadata:
+  name: example-immutable-backup
+immutability:
+  retentionPeriod: 96h        # Backups are immutable for 4 days
+  retentionType: bucket       # Bucket-level immutability
+  locked: false               # Set to true to lock the policy
+```
+
+> [!NOTE]
+> `GCP` uses lifecycle rules to delay object deletion until the retention period expires. Once `locked: true` is set, the policy cannot be reverted or shortened. See [`GCP` Extension Usage – BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/docs/usage/usage.md#backupbucketconfig)
+
+### `AWS`
+
+```yaml
+apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
+kind: BackupBucketConfig
+metadata:
+  name: example-immutable-backup
+immutability:
+  retentionType: bucket  # Enable S3 Object Lock on bucket
+  retentionPeriod: 96h  # Backups are immutable for 4 days
+  mode: compliance     # or governance
+```
+
+> [!NOTE]
+> `AWS` S3 Object Lock in **COMPLIANCE** mode cannot be overridden by any user, including the bucket owner. See [`AWS` Extension Usage – BackupBucket](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage/usage.md#backupbucket)
+
+### Azure
+
+```yaml
+apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+kind: BackupBucketConfig
+metadata:
+  name: example-immutable-backup
+immutability:
+  retentionPeriod: 96h        # Backups are immutable for 4 days
+  retentionType: bucket       # Container-level immutability
+  locked: true                # Once enabled, policy is irreversible
+```
+
+> [!NOTE]
+> `Azure` uses container immutability policies with delayed deletion. Once `locked: true` is set, the policy cannot be changed or removed.  
+> See [`Azure` Extension Usage – BackupBucket](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage/usage.md#backupbucket)
+
+## Advanced: Ignoring Snapshots During Restoration
+
+Immutable buckets prevent snapshot deletion. If you encounter issues during restore, you may need to skip problematic snapshots.
+
+See [etcd-backup-restore: Ignoring Snapshots During Restoration](https://github.com/gardener/etcd-backup-restore/blob/master/docs/usage/enabling_immutable_snapshots.md#ignoring-snapshots-during-restoration)
+
+## References
+
+- [BackupBucket Resource Contract](../../extensions/resources/backupbucket.md)
+- [Gardenlet Controller Concepts](../../concepts/gardenlet.md#backupbucket-controller)
+- [`GCP` Extension Usage – BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/docs/usage/usage.md#backupbucketconfig)
+- [`AWS` Extension Usage – BackupBucket](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage/usage.md#backupbucket)
+- [`Azure` Extension Usage – BackupBucket](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage/usage.md#backupbucket)
+- [etcd-backup-restore: Enabling Immutable Snapshots](https://github.com/gardener/etcd-backup-restore/blob/master/docs/usage/enabling_immutable_snapshots.md)

--- a/docs/usage/advanced/immutable-backup-buckets.md
+++ b/docs/usage/advanced/immutable-backup-buckets.md
@@ -4,101 +4,100 @@ title: Immutable Backup Buckets
 
 # Immutable Backup Buckets
 
-## Overview 
+## Overview
 
-Immutable backup buckets ensure that etcd backups cannot be modified or deleted after creation, leveraging immutability features provided by supported cloud providers. This is essential for meeting security, compliance, and operational requirements.
+**Immutable backup buckets** ensure that etcd backups cannot be modified or deleted before the configured retention period expires, by leveraging immutability features provided by supported cloud providers.
+
+This capability is critical for:
+
+* **Security**: Protecting against accidental or malicious deletion of backups.
+* **Compliance**: Meeting regulatory requirements for data retention.
+* **Operational integrity**: Ensuring recoverable state of your Kubernetes clusters.
 
 > [!NOTE]
 > For background, see [Gardener Issue #10866](https://github.com/gardener/gardener/issues/10866).
 
 ## Core Concepts
 
-Gardener provider extensions support immutable backup buckets for some hyperscalers, e.g., `AWS`, `GCP`, and `Azure`. When enabled, the extension will:
+When **immutability** is enabled via a supported Gardener provider extension:
 
-- **Create** buckets with the specified immutability policy if they do not exist.
-- **Reconcile** existing buckets to enforce the desired immutability policy.
-- **Prevent** reducing the retention period or disabling immutability once the policy is locked.
-- **Apply** lifecycle-based delayed deletion on `GCP` and `Azure` when immediate deletion is not permitted.
+The **provider extension** will:
 
-> [!IMPORTANT]
-> Once immutability is locked, it cannot be disabled or shortened.
+* ✅ **Create** the backup bucket with the desired immutability policy (if it does not already exist).
+* 🔄 **Reconcile** the policy on existing buckets to match the current configuration.
+* 🚫 **Prevent changes** that would weaken the policy (reduce retention period or disable immutability).
+* 🕑 **Manage deletion lifecycle**: If retention lock prevents immediate deletion of objects, a deletion policy will apply when allowed.
 
-## Admission Webhook Enforcement
+> \[!IMPORTANT]
+> Once a bucket's immutability is **locked** at the cloud provider level, it cannot be removed or shortened—even by administrators or operators.
 
-An admission webhook ensures:
+## Provider Support
+> [!WARNING]
+> **Not all Gardener provider extensions currently support immutable buckets.**
+Support and configuration options vary between providers.
 
-- **Locking:** Once `locked: true`, immutability cannot be disabled.
-- **Retention:** Once the retention period is set and locked, it cannot be decreased.
+Please check your cloud provider’s extension documentation (see [References](#references)) for up-to-date support and syntax.
 
-## Configuration
+## How It Works: Admission Webhook Enforcement
 
-To enable immutable backup buckets, specify the immutability settings in `.spec.backup.providerConfig` in the `Seed` resource. The gardenlet will automatically create or update the bucket according to the configuration.
+To ensure backup integrity, an **admission webhook** enforces:
 
-- See [BackupBucket Resource Contract](../../extensions/resources/backupbucket.md)
-- See [Gardenlet Controller Concepts – BackupBucket Controller](../../concepts/gardenlet.md#backupbucket-controller)
+* 🔒 **Immutability lock**: Once the policy is locked, it cannot be disabled.
+* 📅 **Retention period**: Once the policy is locked, the retention period cannot be shortened.
 
-## Example Configurations
+This protects clusters from accidental misconfiguration or policy drift.
 
-### `GCP`
+## How to Enable Immutable Backup Buckets
+
+To enable immutable backup buckets:
+1️⃣ Set the **immutability options** in `.spec.backup.providerConfig` of your `Seed` resource.
+2️⃣ The **Gardenlet** and the provider extension will collaborate to provision and manage the bucket.
+
+### Example Configuration
+
+Below is a **generic example**; adjust according to your cloud provider’s API:
 
 ```yaml
-apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
-kind: BackupBucketConfig
+apiVersion: core.gardener.cloud/v1beta1
+kind: Seed
 metadata:
-  name: example-immutable-backup
-immutability:
-  retentionPeriod: 96h        # Backups are immutable for 4 days
-  retentionType: bucket       # Bucket-level immutability
-  locked: false               # Set to true to lock the policy
+  name: example-seed
+spec:
+  backup:
+    provider: <provider-name>
+    providerConfig:
+      apiVersion: <provider-extension-api-version>
+      kind: BackupBucketConfig
+      immutability:
+        retentionPeriod: 96h          # Required: Retention duration (e.g., 96h)
+        retentionType: bucket         # Bucket-level or object-level (provider-specific)
+        locked: false                 # Whether to lock policy on creation (recommended: true for production)
 ```
 
 > [!NOTE]
-> `GCP` uses lifecycle rules to delay object deletion until the retention period expires. Once `locked: true` is set, the policy cannot be reverted or shortened. See [`GCP` Extension Usage – BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/docs/usage/usage.md#backupbucketconfig)
+> See your provider’s documentation for specific fields and behavior:
+>
+> * [GCP BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/docs/usage/usage.md#backupbucketconfig)
+> * [AWS BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage/usage.md#backupbucketconfig)
+> * [Azure BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage/usage.md#backupbucketconfig)
 
-### `AWS`
-
-```yaml
-apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
-kind: BackupBucketConfig
-metadata:
-  name: example-immutable-backup
-immutability:
-  retentionType: bucket  # Enable S3 Object Lock on bucket
-  retentionPeriod: 96h  # Backups are immutable for 4 days
-  mode: compliance     # or governance
-```
-
-> [!NOTE]
-> `AWS` S3 Object Lock in **COMPLIANCE** mode cannot be overridden by any user, including the bucket owner. See [`AWS` Extension Usage – BackupBucket](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage/usage.md#backupbucket)
-
-### Azure
-
-```yaml
-apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
-kind: BackupBucketConfig
-metadata:
-  name: example-immutable-backup
-immutability:
-  retentionPeriod: 96h        # Backups are immutable for 4 days
-  retentionType: bucket       # Container-level immutability
-  locked: true                # Once enabled, policy is irreversible
-```
-
-> [!NOTE]
-> `Azure` uses container immutability policies with delayed deletion. Once `locked: true` is set, the policy cannot be changed or removed.  
-> See [`Azure` Extension Usage – BackupBucket](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage/usage.md#backupbucketconfig)
 
 ## Advanced: Ignoring Snapshots During Restoration
 
-Immutable buckets prevent snapshot deletion. If you encounter issues during restore, you may need to skip problematic snapshots.
+When using immutable backup buckets, you may encounter situations where certain snapshots cannot be deleted due to immutability constraints. In such cases, you can configure the etcd-backup-restore tool to **ignore problematic snapshots** during restoration.
+This allows you to proceed with restoring the etcd cluster without being blocked by snapshots that cannot be deleted.
 
-See [etcd-backup-restore: Ignoring Snapshots During Restoration](https://github.com/gardener/etcd-backup-restore/blob/master/docs/usage/enabling_immutable_snapshots.md#ignoring-snapshots-during-restoration)
+> [!WARNING]
+> **Ignoring snapshots should be used with caution**. It is recommended to only ignore snapshots that you are certain are not needed for recovery, as this may lead to data loss if critical snapshots are skipped.
+
+👉 See: [Ignoring Snapshots During Restoration](https://github.com/gardener/etcd-backup-restore/blob/master/docs/usage/enabling_immutable_snapshots.md#ignoring-snapshots-during-restoration).
+
 
 ## References
 
-- [BackupBucket Resource Contract](../../extensions/resources/backupbucket.md)
-- [Gardenlet Controller Concepts](../../concepts/gardenlet.md#backupbucket-controller)
-- [`GCP` Extension Usage – BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/docs/usage/usage.md#backupbucketconfig)
-- [`AWS` Extension Usage – BackupBucket](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage/usage.md#backupbucket)
-- [`Azure` Extension Usage – BackupBucket](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage/usage.md#backupbucket)
-- [etcd-backup-restore: Enabling Immutable Snapshots](https://github.com/gardener/etcd-backup-restore/blob/master/docs/usage/enabling_immutable_snapshots.md)
+* [BackupBucket Resource Contract](../../extensions/resources/backupbucket.md)
+* [Gardenlet Controller Concepts – BackupBucket Controller](../../concepts/gardenlet.md#backupbucket-controller)
+* [GCP BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/docs/usage/usage.md#backupbucketconfig)
+* [AWS BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage/usage.md#backupbucketconfig)
+* [Azure BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage/usage.md#backupbucketconfig)
+* [etcd-backup-restore: Enabling Immutable Snapshots](https://github.com/gardener/etcd-backup-restore/blob/master/docs/usage/enabling_immutable_snapshots.md)

--- a/docs/usage/advanced/immutable-backup-buckets.md
+++ b/docs/usage/advanced/immutable-backup-buckets.md
@@ -13,7 +13,7 @@ Immutable backup buckets ensure that etcd backups cannot be modified or deleted 
 
 ## Core Concepts
 
-Gardener supports immutable backup buckets for `AWS`, `GCP`, and `Azure` via their respective provider extensions. When enabled, the extension will:
+Gardener provider extensions support immutable backup buckets for some hyperscalers, e.g., `AWS`, `GCP`, and `Azure`. When enabled, the extension will:
 
 - **Create** buckets with the specified immutability policy if they do not exist.
 - **Reconcile** existing buckets to enforce the desired immutability policy.
@@ -86,7 +86,7 @@ immutability:
 
 > [!NOTE]
 > `Azure` uses container immutability policies with delayed deletion. Once `locked: true` is set, the policy cannot be changed or removed.  
-> See [`Azure` Extension Usage – BackupBucket](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage/usage.md#backupbucket)
+> See [`Azure` Extension Usage – BackupBucket](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage/usage.md#backupbucketconfig)
 
 ## Advanced: Ignoring Snapshots During Restoration
 

--- a/example/50-seed.yaml
+++ b/example/50-seed.yaml
@@ -16,8 +16,16 @@ spec:
 # If you don't want to have backups then don't specify the `.spec.backup` key.
   backup:
     provider: <provider-name> # e.g., aws, azure, gcp, ...
-  # providerConfig:
-  #   <some-provider-specific-config-for-the-backup-buckets>
+    # providerConfig:
+    #   apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+    #   kind: BackupBucketConfig
+    #   metadata:
+    #     name: example-immutable-backup
+    #   immutability:
+    #     retentionPeriod: 96h        # Backups are immutable for 4 days
+    #     retentionType: bucket       # Bucket-level immutability
+    #     locked: false               # Set to true to lock the policy, applicable only to provider: gcp, azure
+    #     mode: compliance/governance     # applicable only to provider: aws
     region: europe-1
     credentialsRef:
       apiVersion: v1

--- a/example/50-seed.yaml
+++ b/example/50-seed.yaml
@@ -16,16 +16,8 @@ spec:
 # If you don't want to have backups then don't specify the `.spec.backup` key.
   backup:
     provider: <provider-name> # e.g., aws, azure, gcp, ...
-    # providerConfig:
-    #   apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
-    #   kind: BackupBucketConfig
-    #   metadata:
-    #     name: example-immutable-backup
-    #   immutability:
-    #     retentionPeriod: 96h        # Backups are immutable for 4 days
-    #     retentionType: bucket       # Bucket-level immutability
-    #     locked: false               # Set to true to lock the policy, applicable only to provider: gcp, azure
-    #     mode: compliance/governance     # applicable only to provider: aws
+  # providerConfig:
+  #   <some-provider-specific-config-for-the-backup-buckets>
     region: europe-1
     credentialsRef:
       apiVersion: v1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup 
/area compliance
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR adds a new usage guide for immutable backup buckets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
A new usage guide for immutable backup buckets has been added, providing configuration examples and operational guidance for AWS, GCP, and Azure.
```
